### PR TITLE
doc: 📓 Updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Google OAuth example in SvelteKit
+# Google OAuth example in Next.js
 
 Uses SQLite. Rate limiting is implemented using JavaScript `Map`.
 


### PR DESCRIPTION
Updating the README to say Next.js, not SvelteKit.

![Stallone 2024-11-21 at 09 31 59@2x](https://github.com/user-attachments/assets/0086b79b-1051-4b77-b751-283ab5c689c5)
